### PR TITLE
Surface error cause in MercadoPagoError

### DIFF
--- a/lib/mercadopago.js
+++ b/lib/mercadopago.js
@@ -10,11 +10,12 @@ var config = {
 	MIME_FORM: "application/x-www-form-urlencoded"
 };
 
-function MercadoPagoError(message, status) {
+function MercadoPagoError(message, status, cause) {
 	this.name = "MercadoPagoError";
 	this.message = message || "MercadoPago Unknown error";
 	this.stack = (new Error()).stack;
 	this.status = status || 500;
+        this.cause = cause || [];
 }
 
 MercadoPagoError.prototype = Object.create(Error.prototype);
@@ -524,7 +525,7 @@ var MPRestClient = (function() {
 			if (error) {
 				deferred.reject (new MercadoPagoError(error));
 			} else if (response.statusCode < 200 || response.statusCode >= 300) {
-				deferred.reject (new MercadoPagoError(body ? body.message || body : "Unknown", response.statusCode));
+				deferred.reject (new MercadoPagoError(body ? body.message || body : "Unknown", response.statusCode, body ? body.cause : ""));
 			} else {
 				try {
 					(typeof body == "string") && (body = JSON.parse(body));

--- a/lib/mercadopago.js
+++ b/lib/mercadopago.js
@@ -15,7 +15,7 @@ function MercadoPagoError(message, status, cause) {
 	this.message = message || "MercadoPago Unknown error";
 	this.stack = (new Error()).stack;
 	this.status = status || 500;
-        this.cause = cause || [];
+	this.cause = cause || [];
 }
 
 MercadoPagoError.prototype = Object.create(Error.prototype);


### PR DESCRIPTION
The error details for common errors like 'invalid_parameters' are returned within the response body in a `cause` property (array).  When catching the MercadoPagoError from outside the library this information is lost if we don't inspect the request.

Feedback is welcomed. Thanks!