### PR TITLE
Removing reserved words that failed strict mode

### DIFF
--- a/lib/mercadopago-support.js
+++ b/lib/mercadopago-support.js
@@ -1,4 +1,4 @@
-var package = require('../package');
+var pack = require('../package');
 var configurations = require('./configurations');
 var requestManager = require('./request-manager');
 var paymentModule = require('./resources/payment');
@@ -371,6 +371,6 @@ module.exports = function () {
     refundPayment: refundPayment,
     cancelPayment: cancelPayment,
     cancelPreapprovalPayment: cancelPreapprovalPayment,
-    version: package.version
+    version: pack.version
   };
 };


### PR DESCRIPTION
the word "package" in mercadopago-support was causing build fail in strict mode, simply abbreviating it fixes the issue