### PR TITLE
fix: avoid TypeError exception when upstream servers are down

### DIFF
--- a/lib/request-manager.js
+++ b/lib/request-manager.js
@@ -339,6 +339,7 @@ requestManager.exec = function (options, callback) {
       }
 
       if (response.statusCode < 200 || (response.statusCode >= 300 && response.statusCode !== 304)) {
+        if (!body) body = {}; // We do this to avoid that we get an error when accessing a body object property. This way body.message would generate undefined.
         // Create a mercadopagoError allowing to retry the operation
         mpError = new MercadoPagoError(body.message, body.cause, response.statusCode, req.headers['x-idempotency-key'],
           options, this);


### PR DESCRIPTION
It appears that today some MercadoPago servers were not responding correctly and were not returning the appropriate response to the SDK. I presume that the error was of 5XX and that is ok, sometimes bad things happens, but this SDK must be ready for it. In this case `body` was undefined and we got an `TypeError: Cannot read property 'message' of undefined`
because of this line:
```
node_modules/mercadopago/lib/request-manager.js:344
        mpError = new MercadoPagoError(body.message, body.cause, response.statusCode,...
```

## Cambios realizados para el feature:
 * Checks to avoid TypeError
 
## Issues cerrados
None
 

## Checklist validación PR:

- [x] Título y descripción clara del PR
- [x] Tests de mi funcionalidad 
- [x] Documentación de mi funcionalidad
- [x] Tests ejecutados y pasados
- [x] Branch Coverage >= 80%
