### PR TITLE
Refactor: (query-params) replace hasOwnProperty with typeof check to avoid false positives

### DIFF
--- a/src/utils/restClient/index.ts
+++ b/src/utils/restClient/index.ts
@@ -20,7 +20,7 @@ class RestClient {
 		const searchParams = new URLSearchParams();
 
 		for (const key in queryParams) {
-			if (typeof queryParams?.[key] !== 'undefined') {
+			if (Object.prototype.hasOwnProperty.call(queryParams,key) && typeof queryParams[key] !== 'undefined') {
 				searchParams.append(key, queryParams[key].toString());
 			}
 		}

--- a/src/utils/restClient/index.ts
+++ b/src/utils/restClient/index.ts
@@ -20,7 +20,7 @@ class RestClient {
 		const searchParams = new URLSearchParams();
 
 		for (const key in queryParams) {
-			if (Object.prototype.hasOwnProperty.call(queryParams, key)) {
+			if (typeof queryParams?.[key] !== 'undefined') {
 				searchParams.append(key, queryParams[key].toString());
 			}
 		}


### PR DESCRIPTION
## 📝 Description

- The way that Object.hasOwnProperty handles data is similar to Object.keys ignoring the value of the data. Objects passed as the following example result in an error:

```json
{
  begin_date: undefined,
  end_date: undefined,
  offset: 1,
  limit: 20,
  external_reference: undefined
}
```

```bash
Cannot read properties of undefined (reading 'toString')
```

- The change consists of treating data by its values and not by the existence of the key in the object. Null, empty string, and false will not cause errors when calling toString() because this function is defined for these values in JavaScript. Only undefined will cause an error when trying to call toString(). Checking only undefined is enough to avoid these errors.

### ✅ Checklist:

- [x] I followed the instructions indicated in [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I added the changes to CHANGELOG
- [ ] Added the necessary tests for the code or functionality that I'm working on
- [x] I ran the tests and made sure they work
- [x] My branch coverage is at least 80%
- [x] I verified the style of my code matches the one in the project

## 🧰 How to reproduce

- [x] Not Apply.
- [ ] Step by step of how to test, specially for bugs.
- [ ] Links of external docs.

## 📸 Screenshots

- [x] Not Apply.
- [ ] Before and after, if it's a fix for a bug.

## 📄 References

- [x] Not Apply.
- [ ] Links do external documentation.
- [ ] Diagrams.
- [ ] Useful links.
