### PR TITLE
feat: adding fields related to network_transaction_id

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,9 @@
 # Releases
 
+## VERSION 2.8.0
+
+- Add Network-Transaction-ID
+
 ## VERSION 2.7.0
 
 - Add Order industry fields

--- a/src/clients/payment/commonTypes.ts
+++ b/src/clients/payment/commonTypes.ts
@@ -217,6 +217,18 @@ export declare type ThreeDSInfo = {
   creq?: string;
 };
 
+export declare type GatewayReference = {
+  network_transaction_id?: string;
+};
+
+export declare type Gateway = {
+  reference?: GatewayReference;
+};
+
+export declare type Expanded = {
+  gateway?: Gateway;
+};
+
 export declare interface PaymentResponse extends ApiResponse {
   id?: number;
   date_created?: string;
@@ -280,5 +292,6 @@ export declare interface PaymentResponse extends ApiResponse {
   payment_method_option_id?: string;
   taxes?: Array<Tax>
   internal_metadata?: any;
+  expanded?: Expanded;
 }
 

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -5,7 +5,7 @@ export class AppConfig {
 	static readonly BASE_URL = 'https://api.mercadopago.com';
 	static readonly PRODUCT_ID = 'bc32b6ntrpp001u8nhkg';
 
-	static SDK_VERSION = '2.7.0';
+	static SDK_VERSION = '2.8.0';
 
 	static readonly Headers = {
 		AUTHORIZATION: 'Authorization',


### PR DESCRIPTION
Adding network_transaction_id related fields to payments response.

```
"expanded": {
   "gateway": {
 	  "reference": {
 		 "network_transaction_id": "xxxxx"
 	    }
    }
}
```
