### PR TITLE
implement and update fields and tests

### DIFF
--- a/e2e/order/cancel.spec.ts
+++ b/e2e/order/cancel.spec.ts
@@ -11,7 +11,7 @@ function createBodyOrder(token: string): OrderCreateData {
 		body: {
 			type: 'online',
 			processing_mode: 'automatic',
-			capture_mode: 'manual',
+			capture_mode: 'automatic_async',
 			total_amount: '200.00',
 			external_reference: 'ext_ref_1234',
 			transactions: {

--- a/e2e/order/capture.spec.ts
+++ b/e2e/order/capture.spec.ts
@@ -11,7 +11,7 @@ function createBodyOrder(token: string): OrderCreateData {
 		body: {
 			type: 'online',
 			processing_mode: 'automatic',
-			capture_mode: 'manual',
+			capture_mode: 'automatic_async',
 			total_amount: '200.00',
 			external_reference: 'ext_ref_1234',
 			transactions: {

--- a/src/clients/order/create/create.spec.ts
+++ b/src/clients/order/create/create.spec.ts
@@ -51,3 +51,176 @@ describe('Create Order', () => {
 		);
 	});
 });
+
+
+
+describe('Create Order', () => {
+	test('should support payment_method.id = "boleto" in request and response', async () => {
+		const config = new MercadoPagoConfig({ accessToken: 'access_token', options: { timeout: 5000 } });
+		const mockBody: CreateOrderRequest = {
+			type: 'online',
+			total_amount: '1000.00',
+			external_reference: 'ext_ref_1234',
+			transactions: {
+				payments: [
+					{
+						amount: '1000.00',
+						payment_method: {
+							id: 'boleto',
+							type: 'ticket',
+						},
+					},
+				],
+			},
+			payer: {
+				email: createEmailTestUser(),
+			},
+			additional_info: {
+				payer: {
+					authentication_type: 'senha',
+				}
+			}
+		};
+		const mockCreate: OrderCreateClient = {
+			body: mockBody,
+			config
+		};
+		const spyFetch = jest.spyOn(RestClient, 'fetch');
+
+		(RestClient.fetch as jest.Mock).mockResolvedValue({
+			transactions: {
+				payments: [
+					{
+						payment_method: {
+							id: 'boleto',
+							type: 'ticket'
+						}
+					}
+				]
+			},
+			status: 'processed'
+		});
+
+		const response = await create(mockCreate);
+
+		expect(spyFetch).toHaveBeenCalledWith('/v1/orders',
+			{
+				body: JSON.stringify(mockBody),
+				headers: {
+					Authorization: 'Bearer access_token'
+				},
+				method: 'POST',
+				timeout: 5000
+			}
+		);
+
+		expect(response.transactions.payments[0].payment_method.id).toBe('boleto');
+	});
+});
+
+describe('Create Order', () => {
+	test('should support capture_mode = "automatic_async" in request and response', async () => {
+		const config = new MercadoPagoConfig({ accessToken: 'access_token', options: { timeout: 5000 } });
+		const mockBody = {
+			type: 'online',
+			total_amount: '1000.00',
+			capture_mode: 'automatic_async',
+			external_reference: 'ext_ref_1234',
+			transactions: {
+				payments: [
+					{
+						amount: '1000.00',
+						payment_method: {
+							id: 'master',
+							type: 'credit_card',
+							token: 'card_token',
+							installments: 1
+						},
+					},
+				],
+			},
+			payer: {
+				email: createEmailTestUser(),
+			},
+			additional_info: {
+				payer: {
+					authentication_type: 'senha',
+				}
+			}
+		};
+
+		const mockCreate = {
+			body: mockBody,
+			config
+		};
+
+		const spyFetch = jest.spyOn(RestClient, 'fetch');
+
+		(RestClient.fetch as jest.Mock).mockResolvedValue({
+			capture_mode: 'automatic_async',
+			status: 'processed'
+		});
+
+		const response = await create(mockCreate);
+
+		expect(spyFetch).toHaveBeenCalledWith(
+			'/v1/orders',
+			{
+				body: JSON.stringify(mockBody),
+				headers: {
+					Authorization: 'Bearer access_token'
+				},
+				method: 'POST',
+				timeout: 5000
+			}
+		);
+
+		expect(response.capture_mode).toBe('automatic_async');
+	});
+});
+
+describe('Create Order', () => {
+	test('should support additional_info.payer.authentication_type in request', async () => {
+		const config = new MercadoPagoConfig({ accessToken: 'access_token', options: { timeout: 5000 } });
+		const mockBody = {
+			type: 'online',
+			total_amount: '1000.00',
+			external_reference: 'ext_ref_1234',
+			transactions: {
+				payments: [
+					{
+						amount: '1000.00',
+						payment_method: {
+							id: 'master',
+							type: 'credit_card',
+							token: 'card_token',
+							installments: 1
+						}
+					}
+				]
+			},
+			payer: {
+				email: createEmailTestUser(),
+			},
+			additional_info: {
+				payer: {
+					authentication_type: 'senha',
+				}
+			}
+		};
+
+		const mockCreate = {
+			body: mockBody,
+			config
+		};
+		const spyFetch = jest.spyOn(RestClient, 'fetch');
+		(RestClient.fetch as jest.Mock).mockResolvedValue({ status: 'processed' });
+
+		await create(mockCreate);
+
+		expect(spyFetch).toHaveBeenCalledWith('/v1/orders',
+			expect.objectContaining({ body: expect.stringContaining('"authentication_type":"senha"')
+			})
+		);
+	});
+});

--- a/src/clients/order/create/types.ts
+++ b/src/clients/order/create/types.ts
@@ -1,20 +1,15 @@
-// API version: 7d364c51-04c7-45e3-af61-f82423bcc39c
-
-import { Phone } from '@src/clients/commonTypes';
-import { MercadoPagoConfig } from '@src/mercadoPagoConfig';
-import { Options } from '@src/types';
+import { Phone } from '../../../clients/commonTypes';
+import { MercadoPagoConfig } from '../../../mercadoPagoConfig';
+import { Options } from '../../../types';
 import { Address, AutomaticPayments, Config, Identification, Item, StoredCredential, SubscriptionData } from '../commonTypes';
-
 export declare type OrderCreateClient = {
 	body: CreateOrderRequest;
 	config: MercadoPagoConfig;
-}
-
+};
 export declare type OrderCreateData = {
 	body: CreateOrderRequest;
 	requestOptions?: Options;
-}
-
+};
 export declare type CreateOrderRequest = {
 	type?: string;
 	external_reference?: string;
@@ -30,12 +25,81 @@ export declare type CreateOrderRequest = {
 	config?: Config;
 	checkout_available_at?: string;
 	expiration_time?: string;
-}
-
+	additional_info?: AdditionalInfo;
+};
 export declare type TransactionsRequest = {
 	payments?: PaymentRequest[];
+};
+export interface AdditionalInfo {
+	payer?: {
+		authentication_type?: string;
+		registration_date?: string;
+		is_prime_user?: boolean;
+		is_first_purchase_online?: boolean;
+		last_purchase?: string;
+	};
+	shipment?: {
+		express?: boolean;
+		local_pickup?: boolean;
+	};
+	platform?: {
+		shipment?: {
+			delivery_promise?: string;
+			drop_shipping?: string;
+			safety?: string;
+			tracking?: {
+				code?: string;
+				status?: string;
+				withdrawn?: boolean;
+			};
+		};
+		seller?: {
+			id?: string;
+			name?: string;
+			email?: string;
+			status?: string;
+			referral_url?: string;
+			registration_date?: string;
+			hired_plan?: string;
+			business_type?: string;
+			address?: {
+				zip_code?: string;
+				street_name?: string;
+				street_number?: string;
+				city?: string;
+				state?: string;
+				complement?: string;
+				country?: string;
+			};
+			identification?: {
+				type?: string;
+				number?: string;
+			};
+			phone?: {
+				area_code?: string;
+				number?: string;
+			};
+		};
+		authentication?: string;
+	};
+	travel?: {
+		passengers?: Array<{
+			first_name: string;
+			last_name: string;
+			identification: {
+				type: string;
+				number: string;
+			};
+		}>;
+		routes?: Array<{
+			departure: string;
+			destination: string;
+			departure_date_time?: string;
+			arrival_date_time?: string;
+			company: string;
+		}>;
+	};
 }
-
 export declare type PaymentRequest = {
 	amount?: string;
 	payment_method?: PaymentMethodRequest;
@@ -43,16 +107,14 @@ export declare type PaymentRequest = {
 	stored_credential?: StoredCredential;
 	subscription_data?: SubscriptionData;
 	expiration_time?: string;
-}
-
+};
 export declare type PaymentMethodRequest = {
 	id?: string;
 	type?: string;
 	token?: string;
 	installments?: number;
 	statement_descriptor?: string;
-}
-
+};
 export declare type PayerRequest = {
 	customer_id?: string;
 	email?: string;
@@ -61,4 +123,5 @@ export declare type PayerRequest = {
 	identification?: Identification;
 	phone?: Phone;
 	address?: Address;
-}
+};
+

--- a/src/clients/order/create/types.ts
+++ b/src/clients/order/create/types.ts
@@ -1,14 +1,6 @@
-
 import { Phone } from '../../../clients/commonTypes';
 import { MercadoPagoConfig } from '../../../mercadoPagoConfig';
 import { Options } from '../../../types';
-
-// API version: acd67b14-97c4-4a4a-840d-0a018c09654f
-
-import { Phone } from '@src/clients/commonTypes';
-import { MercadoPagoConfig } from '@src/mercadoPagoConfig';
-import { Options } from '@src/types';
-
 import { Address, AutomaticPayments, Config, Identification, Item, StoredCredential, SubscriptionData } from '../commonTypes';
 export declare type OrderCreateClient = {
 	body: CreateOrderRequest;
@@ -33,51 +25,8 @@ export declare type CreateOrderRequest = {
 	config?: Config;
 	checkout_available_at?: string;
 	expiration_time?: string;
-
 	additional_info?: AdditionalInfo;
 };
-
-	additional_info?: {
-		'payer.authentication_type'?: string;
-		'payer.registration_date'?: string;
-		'payer.is_prime_user'?: boolean;
-		'payer.is_first_purchase_online'?: boolean;
-		'payer.last_purchase'?: string;
-		'shipment.express'?: boolean;
-		'shipment.local_pickup'?: boolean;
-		'platform.shipment.delivery_promise'?: string;
-		'platform.shipment.drop_shipping'?: string;
-		'platform.shipment.safety'?: string;
-		'platform.shipment.tracking.code'?: string;
-		'platform.shipment.tracking.status'?: string;
-		'platform.shipment.withdrawn'?: boolean;
-		'platform.seller.id'?: string;
-		'platform.seller.name'?: string;
-		'platform.seller.email'?: string;
-		'platform.seller.status'?: string;
-		'platform.seller.referral_url'?: string;
-		'platform.seller.registration_date'?: string;
-		'platform.seller.hired_plan'?: string;
-		'platform.seller.business_type'?: string;
-		'platform.seller.address.city'?: string,
-		'platform.seller.address.state'?: string,
-		'platform.seller.address.neighborhood'?: string,
-		'platform.seller.address.street_name'?: string,
-		'platform.seller.address.street_number'?: string,
-		'platform.seller.address.zip_code'?: string,
-		'platform.seller.address.complement'?: string,
-		'platform.seller.address.country'?: string,
-		'platform.seller.identification.type'?: string;
-		'platform.seller.identification.number'?: string;
-		'platform.seller.phone.area_code'?: string;
-		'platform.seller.phone.number'?: string;
-		'platform.authentication'?: string;
-		'travel.passengers'?: PassengerRequest[];
-		'travel.routes'?: RouteRequest[];
-	};
-}
-
-
 export declare type TransactionsRequest = {
 	payments?: PaymentRequest[];
 };
@@ -168,27 +117,11 @@ export declare type PaymentMethodRequest = {
 };
 export declare type PayerRequest = {
 	customer_id?: string;
-	entity_type?: string;
 	email?: string;
 	first_name?: string;
 	last_name?: string;
 	identification?: Identification;
 	phone?: Phone;
 	address?: Address;
+};
 
- };
-}
-
-export declare type PassengerRequest = {
-	first_name?: string;
-	last_name?: string;
-	identification?: Identification;
-}
-
-export declare type RouteRequest = {
-	departure?: string;
-	destination?: string;
-	departure_date_time?: string;
-	arrival_date_time?: string;
-	company?: string;
-}

--- a/src/examples/order/cancel.ts
+++ b/src/examples/order/cancel.ts
@@ -17,7 +17,7 @@ async function createOrder(): Promise<string> {
 			body: {
 				type: 'online',
 				processing_mode: 'automatic',
-				capture_mode: 'manual',
+				capture_mode: 'automatic_async',
 				total_amount: '100.00',
 				external_reference: 'ext_ref_1234',
 				payer: {

--- a/src/examples/order/capture.ts
+++ b/src/examples/order/capture.ts
@@ -17,7 +17,7 @@ async function createOrder(): Promise<string> {
 			body: {
 				type: 'online',
 				processing_mode: 'automatic',
-				capture_mode: 'manual',
+				capture_mode: 'automatic_async',
 				total_amount: '100.00',
 				external_reference: 'ext_ref_1234',
 				payer: {

--- a/src/examples/payment/create.ts
+++ b/src/examples/payment/create.ts
@@ -24,17 +24,7 @@ payment.create({
 		// installments: 1, // Required for credit card payments
 		// token: '<CARD_TOKEN>', // Required for credit card payments
 	},
-
 	requestOptions: {
 		idempotencyKey: '<IDEMPOTENCY_KEY>'
 	}
 }).then(console.log).catch(console.log);
-
-// installments: 1, // Required for credit card payments
-// token: '<CARD_TOKEN>', // Required for credit card payments
-},
-requestOptions: {
-	idempotencyKey: '<IDEMPOTENCY_KEY>'
-} }).then(console.log).catch(console.log);
-
-

--- a/src/examples/payment/create.ts
+++ b/src/examples/payment/create.ts
@@ -4,24 +4,27 @@
  * @see {@link https://www.mercadopago.com/developers/en/reference/payments/_payments/post Documentation }.
  */
 
-
 import MercadoPago, { Payment } from '@src/index';
 
-const client = new MercadoPago({ accessToken: '<ACCESS_TOKEN>', options: { timeout: 5000 } });
+const client = new MercadoPago({
+	accessToken: '<ACCESS_TOKEN>',
+	options: { timeout: 5000 }
+});
 
 const payment = new Payment(client);
 
-payment.create({ body: {
-	transaction_amount: 12.34,
-	description: '<DESCRIPTION>',
-	payment_method_id: '<PAYMENT_METHOD_ID>',
-	payer: {
-		email: '<EMAIL>'
+payment.create({
+	body: {
+		transaction_amount: 12.34,
+		description: '<DESCRIPTION>',
+		payment_method_id: '<PAYMENT_METHOD_ID>',
+		payer: {
+			email: '<EMAIL>'
+		}
+		// installments: 1, // Required for credit card payments
+		// token: '<CARD_TOKEN>', // Required for credit card payments
 	},
-  	// installments: 1, // Required for credit card payments
-	// token: '<CARD_TOKEN>', // Required for credit card payments
-},
-requestOptions: {
-	idempotencyKey: '<IDEMPOTENCY_KEY>'
-} }).then(console.log).catch(console.log);
-
+	requestOptions: {
+		idempotencyKey: '<IDEMPOTENCY_KEY>'
+	}
+}).then(console.log).catch(console.log);


### PR DESCRIPTION
Atualizar campos para:

- aceitar additional_info na request (não na response)  
- permitir payment_method.id = "boleto" além de bolbradesco  
- incluir automatic_async em capture_mode  
- implementar testes
