### PR TITLE
Fix typo and incorrect JSDoc references in Invoice and PaymentRefund

### DIFF
--- a/src/clients/invoice/index.ts
+++ b/src/clients/invoice/index.ts
@@ -29,8 +29,8 @@ export class Invoice {
    *
    * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/invoice/search.ts Usage Example  }.
    */
-	search(ivoicesSearchOptions: InvoiceSearchData = {}): Promise<InvoiceSearchResponse> {
-		const { options, requestOptions } = ivoicesSearchOptions;
+	search(invoicesSearchOptions: InvoiceSearchData = {}): Promise<InvoiceSearchResponse> {
+		const { options, requestOptions } = invoicesSearchOptions;
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return search({ options, config: this.config });
 	}

--- a/src/clients/paymentRefund/index.ts
+++ b/src/clients/paymentRefund/index.ts
@@ -43,9 +43,9 @@ export class PaymentRefund {
 	}
 
 	/**
-   * Mercado Pago Create Refund.
+   * Mercado Pago Total Refund.
    *
-   * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/paymentRefund/create.ts Usage Example  }.
+   * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/paymentRefund/total.ts Usage Example  }.
    */
 	total({ payment_id, requestOptions }: PaymentRefundTotalData): Promise<RefundResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };

--- a/src/clients/paymentRefund/total/refundTotal.spec.ts
+++ b/src/clients/paymentRefund/total/refundTotal.spec.ts
@@ -6,7 +6,7 @@ import type { PaymentRefundTotalClient } from './types';
 
 jest.mock('@utils/restClient');
 
-describe('Testing payments refunds, create', () => {
+describe('Testing payments refunds, total', () => {
 	test('should successfully make a request with "amount" in the body', async () => {
 		const client = new MercadoPagoConfig({ accessToken: 'token', options: { timeout: 5000 } });
 		const request: PaymentRefundTotalClient = {


### PR DESCRIPTION
## What does this PR fix?

Three copy-paste bugs found in `Invoice` and `PaymentRefund` clients:

### 1. Typo in `Invoice.search()` parameter name
`ivoicesSearchOptions` → `invoicesSearchOptions`

**File:** `src/clients/invoice/index.ts`

### 2. Wrong JSDoc on `PaymentRefund.total()`
The `total()` method had the JSDoc copied from `create()`:
- Description said "Create Refund" instead of "Total Refund"
- Example link pointed to `create.ts` instead of `total.ts` (which already exists)

**File:** `src/clients/paymentRefund/index.ts`

### 3. Wrong `describe` label in `refundTotal.spec.ts`
Test suite said `"Testing payments refunds, create"` but tests the `total` function.

**File:** `src/clients/paymentRefund/total/refundTotal.spec.ts`

## Testing
All existing tests pass with no modifications required.
