### PR TITLE
Enhancement: Add missing Orders API fields and Search operation

### DIFF
--- a/src/clients/order/commonTypes.ts
+++ b/src/clients/order/commonTypes.ts
@@ -28,10 +28,15 @@ export declare interface OrderResponse extends ApiResponse {
 	created_date?: string;
 	last_updated_date?: string;
 	expiration_time?: string;
+	currency?: string;
+	taxes?: TaxResponse[];
+	discounts?: DiscountsResponse;
+	type_response?: TypeResponse;
 }
 
 export declare type PayerResponse = {
 	customer_id?: string;
+	entity_type?: string;
 }
 
 export declare type Config = {
@@ -45,6 +50,10 @@ export declare type PaymentMethodConfig = {
 	default_id?: string;
 	max_installments?: number;
 	default_installments?: number;
+	default_type?: string;
+	installments_cost?: string;
+	installments?: InstallmentsResponse;
+	min_installments?: number;
 }
 
 export declare type OnlineConfig = {
@@ -72,6 +81,7 @@ export declare type SponsorResponse = {
 export declare type TransactionsResponse = {
 	payments?: PaymentResponse[];
 	refunds?: RefundResponse[];
+	chargebacks?: ChargebackResponse[];
 }
 
 export declare interface TransactionsApiResponse extends ApiResponse {
@@ -87,12 +97,15 @@ export declare type PaymentResponse = {
 	attempts?: Attempt[];
 	amount?: string;
 	paid_amount?: string;
+	refunded_amount?: string;
+	provider?: string;
 	payment_method?: PaymentMethodResponse;
 	automatic_payments?: AutomaticPayments;
 	stored_credential?: StoredCredential;
 	subscription_data?: SubscriptionData;
 	date_of_expiration?: string;
 	expiration_time?: string;
+	discounts?: DiscountResponse[];
 }
 
 export declare type AutomaticPayments = {
@@ -153,6 +166,8 @@ export declare type PaymentMethodResponse = {
 	qr_code?: string;
 	qr_code_base64?: string;
 	digitable_line?: string;
+	e2e_id?: string;
+	redirect_url?: string;
 	transaction_security?: TransactionSecurityResponse;
 }
 
@@ -163,6 +178,7 @@ export declare type RefundResponse = {
 	amount?: string;
 	status?: string;
 	items?: Item[];
+	e2e_id?: string;
 }
 
 export declare type Identification = {
@@ -192,6 +208,8 @@ export declare type Item = {
 	picture_url?: string;
 	warranty?: boolean;
 	event_date?: string;
+	unit_measure?: string;
+	external_categories?: ExternalCategoryResponse[];
 }
 
 export declare type PaymentRequest = {
@@ -219,9 +237,59 @@ export declare type TransactionSecurity = {
  * 3DS Transaction Security types for responses
  */
 export declare type TransactionSecurityResponse = {
+	id?: string;
 	validation?: 'always' | 'on_fraud_risk' | 'never';
 	liability_shift?: 'required' | 'preferred';
 	url?: string;
 	type?: string;
 	status?: string;
+}
+
+export declare type TypeResponse = {
+	qr_data?: string;
+}
+
+export declare type TaxResponse = {
+	payer_condition?: string;
+	type?: string;
+	value?: string;
+}
+
+export declare type DiscountsResponse = {
+	payment_methods?: DiscountPaymentMethodResponse[];
+}
+
+export declare type DiscountPaymentMethodResponse = {
+	type?: string;
+	new_total_amount?: string;
+}
+
+export declare type DiscountResponse = {
+	type?: string;
+}
+
+export declare type InstallmentsResponse = {
+	interest_free?: InstallmentsInterestFreeResponse;
+	available?: InstallmentsAvailableResponse;
+}
+
+export declare type InstallmentsInterestFreeResponse = {
+	type?: string;
+	values?: number[];
+}
+
+export declare type InstallmentsAvailableResponse = {
+	type?: string;
+}
+
+export declare type ChargebackResponse = {
+	id?: string;
+	transaction_id?: string;
+	case_id?: string;
+	status?: string;
+	references?: string[];
+}
+
+export declare type ExternalCategoryResponse = {
+	id?: string;
 }

--- a/src/clients/order/create/types.ts
+++ b/src/clients/order/create/types.ts
@@ -27,6 +27,7 @@ export declare type CreateOrderRequest = {
 	expiration_time?: string;
 	currency?: string;
 	additional_info?: Record<string, any>;
+	shipment?: ShipmentRequest;
 };
 export declare type TransactionsRequest = {
 	payments?: PaymentRequest[];
@@ -57,3 +58,17 @@ export declare type PayerRequest = {
 	address?: Address;
 };
 
+export declare type ShipmentRequest = {
+	address?: ShipmentAddressRequest;
+};
+
+export declare type ShipmentAddressRequest = {
+	zip_code?: string;
+	street_name?: string;
+	street_number?: string;
+	neighborhood?: string;
+	city?: string;
+	state?: string;
+	complement?: string;
+	country?: string;
+};

--- a/src/clients/order/index.ts
+++ b/src/clients/order/index.ts
@@ -4,6 +4,7 @@ import process from './process';
 import capture from './capture';
 import cancel from './cancel';
 import refund from './refund';
+import search from './search';
 import createTransaction from './transaction/create';
 import updateTransaction from './transaction/update';
 import deleteTransaction from './transaction/delete';
@@ -16,6 +17,7 @@ import { OrderProcessData } from './process/types';
 import { OrderCaptureData } from './capture/types';
 import { OrderCancelData } from './cancel/types';
 import { OrderRefundData } from './refund/types';
+import { OrderSearchData, OrderSearchResponse } from './search/types';
 import { OrderCreateTransactionData } from './transaction/create/types';
 import { OrderUpdateTransactionData } from './transaction/update/types';
 import { OrderDeleteTransactionData } from './transaction/delete/types';
@@ -92,6 +94,18 @@ export class Order {
 	refund({ id, body, requestOptions }: OrderRefundData): Promise<OrderResponse> {
 		this.config.options = { ...this.config.options, ...requestOptions };
 		return refund({ id, body, config: this.config });
+	}
+
+	/**
+	 * Search Orders.
+	 *
+	 * @see {@link https://github.com/mercadopago/sdk-nodejs/blob/master/src/examples/order/search.ts Usage Example }.
+	 */
+	search(searchData?: OrderSearchData): Promise<OrderSearchResponse> {
+		const options = searchData?.options;
+		const requestOptions = searchData?.requestOptions;
+		this.config.options = { ...this.config.options, ...requestOptions };
+		return search({ options, config: this.config });
 	}
 
 	/**

--- a/src/clients/order/search/index.ts
+++ b/src/clients/order/search/index.ts
@@ -1,0 +1,26 @@
+import { RestClient } from '@src/utils/restClient';
+import { OrderSearchClient, OrderSearchResponse } from './types';
+
+export default function search({ options, config }: OrderSearchClient): Promise<OrderSearchResponse> {
+	const queryParams: Record<string, string | number> = {};
+
+	if (options) {
+		for (const [key, value] of Object.entries(options)) {
+			if (typeof value !== 'undefined') {
+				queryParams[key] = value;
+			}
+		}
+	}
+
+	return RestClient.fetch<OrderSearchResponse>(
+		'/v1/orders',
+		{
+			method: 'GET',
+			headers: {
+				'Authorization': `Bearer ${config.accessToken}`,
+			},
+			queryParams,
+			...config.options
+		}
+	);
+}

--- a/src/clients/order/search/types.ts
+++ b/src/clients/order/search/types.ts
@@ -1,0 +1,40 @@
+import { MercadoPagoConfig } from '@src/mercadoPagoConfig';
+import type { Options } from '@src/types';
+import { OrderResponse } from '../commonTypes';
+
+export declare type OrderSearchData = {
+	options?: OrderSearchRequest;
+	requestOptions?: Options;
+}
+
+export declare type OrderSearchClient = {
+	config: MercadoPagoConfig;
+	options?: OrderSearchRequest;
+}
+
+export declare type OrderSearchRequest = {
+	begin_date: string;
+	end_date: string;
+	external_reference?: string;
+	type?: string;
+	status?: string;
+	status_detail?: string;
+	payment_method_id?: string;
+	payment_method_type?: string;
+	page?: number;
+	page_size?: number;
+	sort_by?: string;
+	sort_order?: string;
+}
+
+export declare type OrderSearchResponse = {
+	data?: OrderResponse[];
+	paging?: PagingResponse;
+}
+
+export declare type PagingResponse = {
+	total?: string;
+	total_pages?: string;
+	offset?: string;
+	limit?: string;
+}


### PR DESCRIPTION
- Add shipment field to CreateOrderRequest (with ShipmentRequest types)
- Add currency, taxes, discounts, type_response to OrderResponse
- Add chargebacks to TransactionsResponse
- Add refunded_amount, provider, discounts to PaymentResponse
- Add e2e_id, redirect_url to PaymentMethodResponse
- Add id to TransactionSecurityResponse
- Add e2e_id to RefundResponse
- Add default_type, installments_cost, installments, min_installments to PaymentMethodConfig
- Add entity_type to PayerResponse
- Add unit_measure, external_categories to Item
- New interfaces: TypeResponse, TaxResponse, DiscountsResponse, DiscountPaymentMethodResponse, DiscountResponse, InstallmentsResponse, InstallmentsInterestFreeResponse, InstallmentsAvailableResponse, ChargebackResponse, ExternalCategoryResponse
- Add search() method to Order client (GET /v1/orders)
