### PR TITLE
Add WebhookSignatureValidator utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,10 @@ export { OAuth } from './clients/oAuth';
 export { MerchantOrder } from './clients/merchantOrder';
 export { User } from './clients/user';
 export { Order } from './clients/order';
+
+export {
+	WebhookSignatureValidator,
+	InvalidWebhookSignatureError,
+	SignatureFailureReason,
+} from './utils/webhook';
+export type { ValidateOptions } from './utils/webhook';

--- a/src/utils/webhook/index.ts
+++ b/src/utils/webhook/index.ts
@@ -1,0 +1,258 @@
+import * as crypto from 'crypto';
+
+/**
+ * MercadoPago webhook signature validator.
+ *
+ * Verifies the authenticity of incoming webhook notifications by recomputing
+ * the HMAC-SHA256 signature locally and comparing it against the value carried
+ * in the `x-signature` header. The implementation is stateless, performs no
+ * outbound HTTP calls, and does not depend on `MercadoPagoConfig` — the
+ * integrator passes the secret signature explicitly on every call.
+ *
+ * @module utils/webhook
+ */
+
+/**
+ * Enumerates the reasons why {@link WebhookSignatureValidator} may reject a
+ * MercadoPago webhook notification.
+ *
+ * Each value maps to a specific failure mode in the signature verification flow.
+ * Integrators are encouraged to log this value alongside the
+ * `x-request-id` for correlation against the MercadoPago notifications dashboard.
+ */
+export enum SignatureFailureReason {
+	/** The `x-signature` header was missing, empty, or whitespace. */
+	MissingSignatureHeader = 'MissingSignatureHeader',
+
+	/**
+	 * The `x-signature` header did not match the expected `ts=...,vN=...`
+	 * format and could not be parsed.
+	 */
+	MalformedSignatureHeader = 'MalformedSignatureHeader',
+
+	/** The header parsed correctly but no `ts=` component was present. */
+	MissingTimestamp = 'MissingTimestamp',
+
+	/**
+	 * The header did not include a hash for any of the versions listed in
+	 * `supportedVersions`. Typically indicates that MercadoPago has migrated to
+	 * a new signature version (e.g. `v2`) and the SDK needs to be upgraded.
+	 */
+	MissingHash = 'MissingHash',
+
+	/**
+	 * The HMAC computed locally did not match the hash provided in the header.
+	 * Most often caused by an incorrect secret signature or by a forged request.
+	 */
+	SignatureMismatch = 'SignatureMismatch',
+
+	/**
+	 * The header timestamp was outside the configured `tolerance` window
+	 * against the current clock. May indicate clock drift on the integrator's
+	 * server or a replay attack.
+	 */
+	TimestampOutOfTolerance = 'TimestampOutOfTolerance',
+}
+
+/**
+ * Error thrown by {@link WebhookSignatureValidator.validate} when a webhook
+ * notification cannot be confirmed as originating from MercadoPago.
+ *
+ * The instance carries enough context to support structured logging without
+ * exposing internal details in the HTTP response.
+ */
+export class InvalidWebhookSignatureError extends Error {
+	/** The specific failure mode that triggered the error. */
+	readonly reason: SignatureFailureReason;
+
+	/** The `x-request-id` header value, when available at the point of failure. */
+	readonly requestId?: string;
+
+	/** The `ts` value extracted from the `x-signature` header, when parsing reached that point. */
+	readonly timestamp?: string;
+
+	constructor(reason: SignatureFailureReason, requestId?: string, timestamp?: string) {
+		super(`Invalid webhook signature: ${reason}`);
+		this.name = 'InvalidWebhookSignatureError';
+		this.reason = reason;
+		this.requestId = requestId;
+		this.timestamp = timestamp;
+		Object.setPrototypeOf(this, InvalidWebhookSignatureError.prototype);
+	}
+}
+
+/**
+ * Arguments accepted by {@link WebhookSignatureValidator.validate}.
+ *
+ * Header and query values may be `string | string[] | null | undefined` to match
+ * the loose shapes that web frameworks (Express, Fastify, etc.) commonly produce.
+ * The validator normalises them internally.
+ */
+export interface ValidateOptions {
+	/** Raw value of the `x-signature` request header. */
+	xSignature: string | string[] | undefined | null;
+
+	/** Raw value of the `x-request-id` request header. */
+	xRequestId: string | string[] | undefined | null;
+
+	/** Value of the `data.id` query string parameter. */
+	dataId: string | string[] | undefined | null;
+
+	/** Secret signature configured for the application in Tus Integraciones. */
+	secret: string;
+
+	/**
+	 * Optional maximum allowed drift in seconds between the timestamp in the
+	 * header and `Date.now()`. Setting a small window (e.g. 300 seconds)
+	 * mitigates replay attacks. Omit to skip the check.
+	 */
+	toleranceSeconds?: number;
+
+	/**
+	 * Optional ordered list of signature versions the validator will accept.
+	 * Defaults to `['v1']`. The validator iterates in order and uses the first
+	 * version found in the header, allowing forward compatibility with future
+	 * signature schemes (e.g. `v2`) without breaking older integrations.
+	 */
+	supportedVersions?: string[];
+
+	/**
+	 * Optional clock function used for the tolerance check. Defaults to
+	 * `Date.now`. Intended for tests; production code should not override.
+	 */
+	now?: () => number;
+}
+
+const DEFAULT_VERSIONS: ReadonlyArray<string> = ['v1'];
+const VERSION_KEY_REGEX = /^v\d+$/;
+
+/**
+ * Stateless utility that validates the signature of a MercadoPago webhook.
+ *
+ * On failure it throws {@link InvalidWebhookSignatureError}; on success it
+ * returns nothing. The comparison is performed in constant time to mitigate
+ * timing attacks.
+ *
+ * QR Code notifications are **not signed** by MercadoPago — do not call this
+ * validator for those events; they will always fail signature verification.
+ */
+export class WebhookSignatureValidator {
+	/**
+	 * Validates the signature of a MercadoPago webhook notification.
+	 *
+	 * @param options - Validation inputs (see {@link ValidateOptions}).
+	 * @throws {@link InvalidWebhookSignatureError} when the signature is missing,
+	 *   malformed, or does not match the expected HMAC.
+	 */
+	static validate(options: ValidateOptions): void {
+		const xSignature = normalise(options.xSignature);
+		const xRequestId = normalise(options.xRequestId);
+		const dataId = normalise(options.dataId);
+		const secret = options.secret;
+		const supportedVersions = options.supportedVersions ?? DEFAULT_VERSIONS;
+		const toleranceSeconds = options.toleranceSeconds;
+		const now = options.now ?? (() => Date.now());
+
+		if (!xSignature) {
+			throw new InvalidWebhookSignatureError(SignatureFailureReason.MissingSignatureHeader, xRequestId);
+		}
+
+		const { ts, hashes } = parseSignatureHeader(xSignature);
+
+		if (!ts && Object.keys(hashes).length === 0) {
+			throw new InvalidWebhookSignatureError(SignatureFailureReason.MalformedSignatureHeader, xRequestId);
+		}
+
+		if (!ts) {
+			throw new InvalidWebhookSignatureError(SignatureFailureReason.MissingTimestamp, xRequestId);
+		}
+
+		if (!/^\d+$/.test(ts)) {
+			throw new InvalidWebhookSignatureError(SignatureFailureReason.MalformedSignatureHeader, xRequestId, ts);
+		}
+
+		let receivedHash: string | undefined;
+		for (const version of supportedVersions) {
+			if (hashes[version]) {
+				receivedHash = hashes[version];
+				break;
+			}
+		}
+
+		if (!receivedHash) {
+			throw new InvalidWebhookSignatureError(SignatureFailureReason.MissingHash, xRequestId, ts);
+		}
+
+		const manifest = buildManifest(dataId, xRequestId, ts);
+		const computedHash = crypto.createHmac('sha256', secret).update(manifest).digest('hex');
+
+		if (!constantTimeEquals(computedHash, receivedHash)) {
+			throw new InvalidWebhookSignatureError(SignatureFailureReason.SignatureMismatch, xRequestId, ts);
+		}
+
+		if (toleranceSeconds !== undefined) {
+			const tsMs = Number(ts);
+			const driftSeconds = Math.abs(now() - tsMs) / 1000;
+			if (driftSeconds > toleranceSeconds) {
+				throw new InvalidWebhookSignatureError(SignatureFailureReason.TimestampOutOfTolerance, xRequestId, ts);
+			}
+		}
+	}
+}
+
+/**
+ * Coerces a header/query value (which may be string, array, null, or undefined)
+ * into a trimmed non-empty string, or `undefined` when the value is missing.
+ */
+function normalise(value: string | string[] | undefined | null): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	const raw = Array.isArray(value) ? value[0] : value;
+	if (raw === undefined || raw === null) return undefined;
+	const trimmed = String(raw).trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parses the `x-signature` header into its `ts` and `vN` components.
+ * Unknown keys are silently ignored.
+ */
+function parseSignatureHeader(header: string): { ts?: string; hashes: Record<string, string> } {
+	const hashes: Record<string, string> = {};
+	let ts: string | undefined;
+
+	for (const part of header.split(',')) {
+		const eq = part.indexOf('=');
+		if (eq === -1) continue;
+		const key = part.substring(0, eq).trim().toLowerCase();
+		const value = part.substring(eq + 1).trim();
+		if (!key || !value) continue;
+		if (key === 'ts') {
+			ts = value;
+		} else if (VERSION_KEY_REGEX.test(key)) {
+			hashes[key] = value;
+		}
+	}
+
+	return { ts, hashes };
+}
+
+/**
+ * Builds the manifest string that will be fed into the HMAC.
+ * Pairs whose value is missing are omitted, per the documented rule.
+ */
+function buildManifest(dataId: string | undefined, requestId: string | undefined, ts: string): string {
+	const parts: string[] = [];
+	if (dataId) parts.push(`id:${dataId.toLowerCase()}`);
+	if (requestId) parts.push(`request-id:${requestId}`);
+	parts.push(`ts:${ts}`);
+	return parts.join(';') + ';';
+}
+
+/**
+ * Constant-time hex-string comparison. Returns `false` (without divulging
+ * lengths via timing) when the strings differ in length.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}

--- a/src/utils/webhook/webhook.spec.ts
+++ b/src/utils/webhook/webhook.spec.ts
@@ -1,0 +1,194 @@
+import * as crypto from 'crypto';
+import {
+	WebhookSignatureValidator,
+	InvalidWebhookSignatureError,
+	SignatureFailureReason,
+} from '.';
+
+const SECRET = 'your_secret_key_here';
+const REQUEST_ID = '2066ca19-c6f1-498a-be75-1923005edd06';
+const DATA_ID_RAW = 'ORD01JQ4S4KY8HWQ6NA5PXB65B3D3';
+const DATA_ID_LOWER = 'ord01jq4s4ky8hwq6na5pxb65b3d3';
+const TS = '1742505638683';
+const TS_NUM = Number(TS);
+
+function computeHash(dataId: string | undefined, requestId: string | undefined, ts: string, secret: string): string {
+	const parts: string[] = [];
+	if (dataId) parts.push(`id:${dataId.toLowerCase()}`);
+	if (requestId) parts.push(`request-id:${requestId}`);
+	parts.push(`ts:${ts}`);
+	return crypto.createHmac('sha256', secret).update(parts.join(';') + ';').digest('hex');
+}
+
+function buildHeader(hash: string, ts: string = TS, version: string = 'v1'): string {
+	return `ts=${ts},${version}=${hash}`;
+}
+
+const validHash = computeHash(DATA_ID_LOWER, REQUEST_ID, TS, SECRET);
+const validHeader = buildHeader(validHash);
+const fixedNow = () => TS_NUM;
+
+describe('WebhookSignatureValidator', () => {
+	describe('happy path', () => {
+		it('case 1 — lowercase dataId passes', () => {
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: validHeader, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET, now: fixedNow,
+			})).not.toThrow();
+		});
+
+		it('case 2 — uppercase dataId is lowercased before HMAC', () => {
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: validHeader, xRequestId: REQUEST_ID, dataId: DATA_ID_RAW, secret: SECRET, now: fixedNow,
+			})).not.toThrow();
+		});
+	});
+
+	describe('malformed / missing header', () => {
+		it('case 3 — malformed header throws MalformedSignatureHeader', () => {
+			try {
+				WebhookSignatureValidator.validate({
+					xSignature: 'this-is-garbage', xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+				});
+				fail('expected throw');
+			} catch (err) {
+				expect(err).toBeInstanceOf(InvalidWebhookSignatureError);
+				expect((err as InvalidWebhookSignatureError).reason).toBe(SignatureFailureReason.MalformedSignatureHeader);
+				expect((err as InvalidWebhookSignatureError).requestId).toBe(REQUEST_ID);
+			}
+		});
+
+		it('case 4 — missing header throws MissingSignatureHeader', () => {
+			try {
+				WebhookSignatureValidator.validate({
+					xSignature: undefined, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+				});
+				fail('expected throw');
+			} catch (err) {
+				expect((err as InvalidWebhookSignatureError).reason).toBe(SignatureFailureReason.MissingSignatureHeader);
+			}
+		});
+
+		it('case 5 — missing ts throws MissingTimestamp', () => {
+			try {
+				WebhookSignatureValidator.validate({
+					xSignature: `v1=${validHash}`, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+				});
+				fail('expected throw');
+			} catch (err) {
+				expect((err as InvalidWebhookSignatureError).reason).toBe(SignatureFailureReason.MissingTimestamp);
+			}
+		});
+
+		it('case 6 — missing v1 throws MissingHash', () => {
+			try {
+				WebhookSignatureValidator.validate({
+					xSignature: `ts=${TS}`, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+				});
+				fail('expected throw');
+			} catch (err) {
+				expect((err as InvalidWebhookSignatureError).reason).toBe(SignatureFailureReason.MissingHash);
+				expect((err as InvalidWebhookSignatureError).timestamp).toBe(TS);
+			}
+		});
+	});
+
+	describe('signature mismatch', () => {
+		it('case 7 — wrong hash throws SignatureMismatch', () => {
+			const tampered = validHash.slice(0, -2) + (validHash.endsWith('00') ? 'ff' : '00');
+			try {
+				WebhookSignatureValidator.validate({
+					xSignature: buildHeader(tampered), xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+				});
+				fail('expected throw');
+			} catch (err) {
+				expect((err as InvalidWebhookSignatureError).reason).toBe(SignatureFailureReason.SignatureMismatch);
+			}
+		});
+	});
+
+	describe('tolerance', () => {
+		it('case 8 — ts outside tolerance throws TimestampOutOfTolerance', () => {
+			const farFuture = () => TS_NUM + 10 * 60 * 1000;
+			try {
+				WebhookSignatureValidator.validate({
+					xSignature: validHeader, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+					toleranceSeconds: 60, now: farFuture,
+				});
+				fail('expected throw');
+			} catch (err) {
+				expect((err as InvalidWebhookSignatureError).reason).toBe(SignatureFailureReason.TimestampOutOfTolerance);
+			}
+		});
+
+		it('ts within tolerance passes', () => {
+			const slightlyAfter = () => TS_NUM + 30 * 1000;
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: validHeader, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+				toleranceSeconds: 60, now: slightlyAfter,
+			})).not.toThrow();
+		});
+	});
+
+	describe('manifest omission rule', () => {
+		it('case 9 — dataId absent excludes id:', () => {
+			const hash = computeHash(undefined, REQUEST_ID, TS, SECRET);
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: buildHeader(hash), xRequestId: REQUEST_ID, dataId: undefined, secret: SECRET,
+			})).not.toThrow();
+		});
+
+		it('case 10 — requestId absent excludes request-id:', () => {
+			const hash = computeHash(DATA_ID_LOWER, undefined, TS, SECRET);
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: buildHeader(hash), xRequestId: undefined, dataId: DATA_ID_LOWER, secret: SECRET,
+			})).not.toThrow();
+		});
+
+		it('case 11 — both absent yields ts: only', () => {
+			const hash = computeHash(undefined, undefined, TS, SECRET);
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: buildHeader(hash), xRequestId: '', dataId: '   ', secret: SECRET,
+			})).not.toThrow();
+		});
+	});
+
+	describe('topic agnostic', () => {
+		it('case 12 — non-payment topic uses same algorithm', () => {
+			const orderDataId = 'ord01abc123';
+			const hash = computeHash(orderDataId, REQUEST_ID, TS, SECRET);
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: buildHeader(hash), xRequestId: REQUEST_ID, dataId: orderDataId, secret: SECRET,
+			})).not.toThrow();
+		});
+	});
+
+	describe('supportedVersions', () => {
+		it('finds v1 when both v1 and v2 are present and only v1 is supported', () => {
+			const header = `ts=${TS},v1=${validHash},v2=aaaa`;
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: header, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+				supportedVersions: ['v1'],
+			})).not.toThrow();
+		});
+
+		it('throws MissingHash when only v2 is in header and only v1 is supported', () => {
+			try {
+				WebhookSignatureValidator.validate({
+					xSignature: `ts=${TS},v2=somehash`, xRequestId: REQUEST_ID, dataId: DATA_ID_LOWER, secret: SECRET,
+					supportedVersions: ['v1'],
+				});
+				fail('expected throw');
+			} catch (err) {
+				expect((err as InvalidWebhookSignatureError).reason).toBe(SignatureFailureReason.MissingHash);
+			}
+		});
+	});
+
+	describe('framework-shape input', () => {
+		it('accepts array values (Express headers can be arrays)', () => {
+			expect(() => WebhookSignatureValidator.validate({
+				xSignature: [validHeader], xRequestId: [REQUEST_ID], dataId: DATA_ID_LOWER, secret: SECRET,
+			})).not.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Adds a stateless utility to verify the authenticity of incoming MercadoPago webhook notifications by recomputing the HMAC-SHA256 signature and comparing it against the `x-signature` header in constant time (timing-attack safe).

## Changes
- `src/utils/webhook/index.ts`: HMAC-SHA256 validator with explicit secret per call, typed failure reasons
- `src/index.ts`: export the validator from the public surface
- `src/utils/webhook/webhook.spec.ts`: unit tests covering success, malformed inputs, timestamp window, hash mismatch

## Test plan
- [ ] CI green