### PR TITLE
chore: add Dependabot version updates and dependency audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 5
-    reviewers:
-      - "mercadopago/backend-sdks"
     assignees:
       - "mercadopago/backend-sdks"
     labels:
@@ -45,8 +43,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 1
-    reviewers:
-      - "mercadopago/backend-sdks"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+# Dependabot version updates — sdk-nodejs
+# Ubicación obligatoria: .github/dependabot.yml
+# Ecosistemas: npm (Node.js) + github-actions
+version: 2
+
+updates:
+  # ── Node.js / npm ────────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "mercadopago/backend-sdks"
+    assignees:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # evita que Dependabot amplíe rangos semver en package.json (ej: ^1.0 → >=1.0 <3.0)
+    # importante para un SDK que otros importan — preserva el contrato de versiones
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ── GitHub Actions (CI) ──────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
       - run: npm ci --legacy-peer-deps
       - run: npm run build
       - run: npm test
+      - name: Dependency audit
+        run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable proactive dependency updates (npm + GitHub Actions), weekly on Mondays at 09:00 America/Bogota, assigned to `mercadopago/backend-sdks`, ignoring semver-major bumps. Includes `groups` for dev/prod deps and `versioning-strategy: increase-if-necessary` to preserve semver contract for integrators
- Add dependency audit step to CI (`npm audit --audit-level=high`) to close the Dependabot loop: PR opened → CI runs → audit confirms CVE resolved → merge

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid (GitHub will show a check in Security → Dependabot after merge)
- [ ] Enable **Dependabot version updates** in Settings → Security & analysis
- [ ] Confirm CI audit step runs on next PR