### PR TITLE
feat(order): add missing AP fields to order request types (IXE-679)

### DIFF
--- a/src/clients/order/commonTypes.ts
+++ b/src/clients/order/commonTypes.ts
@@ -255,6 +255,12 @@ export declare type StoredCredential = {
 	store_payment_method?: boolean;
 	/** Whether this is the initial payment in a stored-credential series. */
 	first_payment?: boolean;
+	/**
+	 * Reference to the previous transaction in a recurring series. Required from the second
+	 * charge onwards to link this payment to the original card-network authorization.
+	 * Type: string (transaction ID).
+	 */
+	prev_transaction_ref?: string;
 }
 
 /**

--- a/src/clients/order/create/types.ts
+++ b/src/clients/order/create/types.ts
@@ -70,6 +70,8 @@ export declare type CreateOrderRequest = {
 	additional_info?: Record<string, any>;
 	/** Shipping details for physical-goods orders. */
 	shipment?: ShipmentRequest;
+	/** Integration metadata identifying the integrator, platform, corporation, and sponsor. */
+	integration_data?: IntegrationDataRequest;
 };
 
 /**
@@ -96,6 +98,11 @@ export declare type PaymentRequest = {
 	subscription_data?: SubscriptionData;
 	/** ISO 8601 duration or date-time controlling payment expiration. */
 	expiration_time?: string;
+	/**
+	 * Absolute date-time (ISO 8601) after which this payment can no longer be collected.
+	 * Distinct from `expiration_time` (relative TTL). Type: string (ISO 8601).
+	 */
+	date_of_expiration?: string;
 };
 
 /**
@@ -168,4 +175,25 @@ export declare type ShipmentAddressRequest = {
 	complement?: string;
 	/** Country name or ISO code. */
 	country?: string;
+};
+
+/**
+ * Integration metadata for an order request. Identifies the integrator, platform,
+ * and corporation associated with the integration, plus any sponsoring marketplace owner.
+ */
+export declare type IntegrationDataRequest = {
+	/** Identifier of the certified integrator. Type: string. */
+	integrator_id?: string;
+	/** Platform identifier assigned by MercadoPago. Type: string. */
+	platform_id?: string;
+	/** Corporation identifier for multi-account setups. Type: string. */
+	corporation_id?: string;
+	/** Sponsor (marketplace owner) information. */
+	sponsor?: SponsorRequest;
+};
+
+/** Sponsoring marketplace owner associated with an order's integration metadata. */
+export declare type SponsorRequest = {
+	/** MercadoPago user ID of the sponsoring marketplace owner. Type: string. */
+	id?: string;
 };


### PR DESCRIPTION
## Summary

- **`commonTypes.ts` / `StoredCredential`** → added `prev_transaction_ref?: string` — links each recurring charge to the original card-network authorization; required from the second charge onwards. Shared type applies to both request (`PaymentRequest`) and response (`PaymentResponse`).
- **`create/types.ts` / `PaymentRequest`** → added `date_of_expiration?: string` (ISO 8601) — absolute payment expiry date, distinct from the relative `expiration_time` TTL.
- **`create/types.ts`** → new type `IntegrationDataRequest`: `integrator_id`, `platform_id`, `corporation_id` (string) + `sponsor: SponsorRequest` — integration metadata for marketplace and platform identification.
- **`create/types.ts`** → new type `SponsorRequest`: `id?: string`.
- **`create/types.ts` / `CreateOrderRequest`** → added `integration_data?: IntegrationDataRequest`.

All fields are optional (`?`). `undefined` values are omitted by `JSON.stringify` — zero break changes.

## Context

Part of IXE-679: fields required for the Automatic Payments (recurring without CVV) flow in the Orders API were missing from the public SDKs. Companion PRs exist for Java, Go, .NET, PHP, Python and Ruby.

## Test plan

- [x] `npm run build` (tsc) — no errors
- [x] `npm test -- --testPathPattern=order` — 13 suites, 18 tests passed, 0 failed
- [ ] Integration/E2E tests (not run per policy)

Generated with [Claude Code](https://claude.com/claude-code)