### PR TITLE
fix(webhook): preserve data.id case in signature manifest

### DIFF
--- a/src/utils/webhook/index.ts
+++ b/src/utils/webhook/index.ts
@@ -242,7 +242,7 @@ function parseSignatureHeader(header: string): { ts?: string; hashes: Record<str
  */
 function buildManifest(dataId: string | undefined, requestId: string | undefined, ts: string): string {
 	const parts: string[] = [];
-	if (dataId) parts.push(`id:${dataId.toLowerCase()}`);
+	if (dataId) parts.push(`id:${dataId}`);
 	if (requestId) parts.push(`request-id:${requestId}`);
 	parts.push(`ts:${ts}`);
 	return parts.join(';') + ';';

--- a/src/utils/webhook/webhook.spec.ts
+++ b/src/utils/webhook/webhook.spec.ts
@@ -14,7 +14,7 @@ const TS_NUM = Number(TS);
 
 function computeHash(dataId: string | undefined, requestId: string | undefined, ts: string, secret: string): string {
 	const parts: string[] = [];
-	if (dataId) parts.push(`id:${dataId.toLowerCase()}`);
+	if (dataId) parts.push(`id:${dataId}`);
 	if (requestId) parts.push(`request-id:${requestId}`);
 	parts.push(`ts:${ts}`);
 	return crypto.createHmac('sha256', secret).update(parts.join(';') + ';').digest('hex');
@@ -36,9 +36,11 @@ describe('WebhookSignatureValidator', () => {
 			})).not.toThrow();
 		});
 
-		it('case 2 — uppercase dataId is lowercased before HMAC', () => {
+		it('case 2 — uppercase dataId is preserved in HMAC', () => {
+			const upperHash = computeHash(DATA_ID_RAW, REQUEST_ID, TS, SECRET);
+			const upperHeader = buildHeader(upperHash);
 			expect(() => WebhookSignatureValidator.validate({
-				xSignature: validHeader, xRequestId: REQUEST_ID, dataId: DATA_ID_RAW, secret: SECRET, now: fixedNow,
+				xSignature: upperHeader, xRequestId: REQUEST_ID, dataId: DATA_ID_RAW, secret: SECRET, now: fixedNow,
 			})).not.toThrow();
 		});
 	});


### PR DESCRIPTION
## Problem

`WebhookSignatureValidator.validate` was calling `.toLowerCase()` on `dataId` before building the HMAC manifest. MercadoPago signs webhook notifications using the original casing of `data.id`, so any notification with uppercase or mixed-case identifiers would fail validation with `SignatureMismatch`.

## Fix

Remove the `.toLowerCase()` call in `buildManifest` so the value is included exactly as received. The test helper and the affected test case are updated to reflect the new behavior.

## Testing

Verified manually with `data.id` values in uppercase (`ORDER123`), lowercase (`order123`), and mixed case (`oRdEr`) — all pass when the signature was generated with the same casing. All 104 unit tests pass.