### PR TITLE
fix: escape dynamic API path parameters

### DIFF
--- a/src/clients/chargeback/get/index.ts
+++ b/src/clients/chargeback/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Get chargeback operation.
  *
@@ -11,7 +12,7 @@ import type { ChargebackResponse } from '../commonTypes';
 
 export default function get({ id, config }: ChargebackGetClient): Promise<ChargebackResponse> {
 	return RestClient.fetch<ChargebackResponse>(
-		`/v1/chargebacks/${id}`,
+		`/v1/chargebacks/${encodePathParam(id)}`,
 		{
 			method: 'GET',
 			headers: {

--- a/src/clients/customer/get/get.spec.ts
+++ b/src/clients/customer/get/get.spec.ts
@@ -12,4 +12,11 @@ describe('Testing customer, get', () => {
 		const spyFetch = jest.spyOn(RestClient, 'fetch');
 		expect(spyFetch).toHaveBeenCalledWith('/v1/customers/123', { 'headers': { 'Authorization': 'Bearer token' }, 'timeout': 5000 });
 	});
+
+	test('should encode customer id as a path segment', async () => {
+		const client = new MercadoPagoConfig({ accessToken: 'token' });
+		await get({ customerId: '../../applications/123', config: client });
+		const spyFetch = jest.spyOn(RestClient, 'fetch');
+		expect(spyFetch).toHaveBeenCalledWith('/v1/customers/..%2F..%2Fapplications%2F123', { 'headers': { 'Authorization': 'Bearer token' } });
+	});
 });

--- a/src/clients/customer/get/index.ts
+++ b/src/clients/customer/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer retrieval operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerResponse } from '../commonTypes';
  */
 export default function get({ customerId, config }: CustomerGetClient): Promise<CustomerResponse> {
 	return RestClient.fetch<CustomerResponse>(
-		`/v1/customers/${customerId}`,
+		`/v1/customers/${encodePathParam(customerId)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/customer/remove/index.ts
+++ b/src/clients/customer/remove/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer removal operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerRemoveClient } from './types';
  */
 export default function remove({ customerId, config }: CustomerRemoveClient): Promise<CustomerResponse> {
 	return RestClient.fetch<CustomerResponse>(
-		`/v1/customers/${customerId}`,
+		`/v1/customers/${encodePathParam(customerId)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/customer/update/index.ts
+++ b/src/clients/customer/update/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer update operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerUpdateClient } from './types';
  */
 export default function update({ customerId, body, config }: CustomerUpdateClient): Promise<CustomerResponse> {
 	return RestClient.fetch<CustomerResponse>(
-		`/v1/customers/${customerId}`,
+		`/v1/customers/${encodePathParam(customerId)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/customerCard/create/index.ts
+++ b/src/clients/customerCard/create/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer card creation operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerCardCreateClient } from './types';
  */
 export default function create({ customerId, body, config }: CustomerCardCreateClient): Promise<CustomerCardResponse> {
 	return RestClient.fetch<CustomerCardResponse>(
-		`/v1/customers/${customerId}/cards`,
+		`/v1/customers/${encodePathParam(customerId)}/cards`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/customerCard/get/index.ts
+++ b/src/clients/customerCard/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer card retrieval operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerCardResponse } from '../commonTypes';
  */
 export default function get({ customerId, cardId, config }: CustomerCardGetRemoveClient): Promise<CustomerCardResponse> {
 	return RestClient.fetch<CustomerCardResponse>(
-		`/v1/customers/${customerId}/cards/${cardId}`,
+		`/v1/customers/${encodePathParam(customerId)}/cards/${encodePathParam(cardId)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/customerCard/list/index.ts
+++ b/src/clients/customerCard/list/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer card list operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerCardResponse } from '../commonTypes';
  */
 export default function list({ customerId, config }: CustomerCardListClient): Promise<CustomerCardResponse[]> {
 	return RestClient.fetch<CustomerCardResponse[]>(
-		`/v1/customers/${customerId}/cards`,
+		`/v1/customers/${encodePathParam(customerId)}/cards`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/customerCard/remove/index.ts
+++ b/src/clients/customerCard/remove/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer card removal operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerCardGetRemoveClient } from '../get/types';
  */
 export default function remove({ customerId, cardId, config }: CustomerCardGetRemoveClient): Promise<CustomerCardResponse> {
 	return RestClient.fetch<CustomerCardResponse>(
-		`/v1/customers/${customerId}/cards/${cardId}`,
+		`/v1/customers/${encodePathParam(customerId)}/cards/${encodePathParam(cardId)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/customerCard/update/index.ts
+++ b/src/clients/customerCard/update/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the customer card update operation.
  *
@@ -19,7 +20,7 @@ import type { CustomerCardUpdateClient } from './types';
  */
 export default function update({ customerId, cardId, body, config }: CustomerCardUpdateClient): Promise<CustomerCardResponse> {
 	return RestClient.fetch<CustomerCardResponse>(
-		`/v1/customers/${customerId}/cards/${cardId}`,
+		`/v1/customers/${encodePathParam(customerId)}/cards/${encodePathParam(cardId)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/invoice/get/index.ts
+++ b/src/clients/invoice/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the get-invoice operation.
  *
@@ -19,7 +20,7 @@ import type { InvoiceResponse } from '@src/clients/invoice/commonTypes';
  */
 export default function get({ id, config }: InvoiceGetClient): Promise<InvoiceResponse> {
 	return RestClient.fetch<InvoiceResponse>(
-		`/authorized_payments/${id}`,
+		`/authorized_payments/${encodePathParam(id)}`,
 		{
 			method: 'GET',
 			headers: {

--- a/src/clients/order/cancel/index.ts
+++ b/src/clients/order/cancel/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Cancel order operation -- sends `POST /v1/orders/{id}/cancel`.
  *
@@ -15,7 +16,7 @@ import { OrderResponse } from '../commonTypes';
  */
 export default function cancel({ id, config }: OrderCancelClient): Promise<OrderResponse> {
 	return RestClient.fetch<OrderResponse>(
-		`/v1/orders/${id}/cancel`,
+		`/v1/orders/${encodePathParam(id)}/cancel`,
 		{
 			method: 'POST',
 			headers: {

--- a/src/clients/order/capture/index.ts
+++ b/src/clients/order/capture/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Capture order operation -- sends `POST /v1/orders/{id}/capture`.
  *
@@ -17,7 +18,7 @@ import { OrderResponse } from '../commonTypes';
  */
 export default function capture({ id, config }: OrderCaptureClient): Promise<OrderResponse> {
 	return RestClient.fetch<OrderResponse>(
-		`/v1/orders/${id}/capture`,
+		`/v1/orders/${encodePathParam(id)}/capture`,
 		{
 			method: 'POST',
 			headers: {

--- a/src/clients/order/get/index.ts
+++ b/src/clients/order/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Get order operation -- sends `GET /v1/orders/{id}`.
  *
@@ -15,7 +16,7 @@ import { OrderResponse } from '../commonTypes';
  */
 export default function get({ id, config }: OrderGetClient): Promise<OrderResponse> {
 	return RestClient.fetch<OrderResponse>(
-		`/v1/orders/${id}`,
+		`/v1/orders/${encodePathParam(id)}`,
 		{
 			method: 'GET',
 			headers: {

--- a/src/clients/order/process/index.ts
+++ b/src/clients/order/process/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Process order operation -- sends `POST /v1/orders/{id}/process`.
  *
@@ -18,7 +19,7 @@ import { OrderResponse } from '../commonTypes';
  */
 export default function process({ id, config }: OrderProcessClient): Promise<OrderResponse> {
 	return RestClient.fetch<OrderResponse>(
-		`/v1/orders/${id}/process`,
+		`/v1/orders/${encodePathParam(id)}/process`,
 		{
 			method: 'POST',
 			headers: {

--- a/src/clients/order/refund/index.ts
+++ b/src/clients/order/refund/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Refund order operation -- sends `POST /v1/orders/{id}/refund`.
  *
@@ -18,7 +19,7 @@ import { OrderResponse } from '../commonTypes';
  */
 export default function refund({ id, body, config }: OrderRefundClient): Promise<OrderResponse> {
 	return RestClient.fetch<OrderResponse>(
-		`/v1/orders/${id}/refund`,
+		`/v1/orders/${encodePathParam(id)}/refund`,
 		{
 			method: 'POST',
 			headers: {

--- a/src/clients/order/transaction/create/index.ts
+++ b/src/clients/order/transaction/create/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Create transaction operation -- sends `POST /v1/orders/{id}/transactions`.
  *
@@ -15,7 +16,7 @@ import { OrderCreateTransactionClient } from './types';
  */
 export default function createTransaction({ id, body, config }: OrderCreateTransactionClient): Promise<TransactionsApiResponse> {
 	return RestClient.fetch<TransactionsApiResponse>(
-		`/v1/orders/${id}/transactions`,
+		`/v1/orders/${encodePathParam(id)}/transactions`,
 		{
 			method: 'POST',
 			headers: {

--- a/src/clients/order/transaction/delete/index.ts
+++ b/src/clients/order/transaction/delete/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Delete transaction operation -- sends `DELETE /v1/orders/{id}/transactions/{transactionId}`.
  *
@@ -15,7 +16,7 @@ import { ApiResponse } from '@src/types';
  */
 export default function deleteTransaction({ id, transactionId, config }: OrderDeleteTransactionClient): Promise<ApiResponse> {
 	return RestClient.fetch(
-		`/v1/orders/${id}/transactions/${transactionId}`,
+		`/v1/orders/${encodePathParam(id)}/transactions/${encodePathParam(transactionId)}`,
 		{
 			method: 'DELETE',
 			headers: {

--- a/src/clients/order/transaction/update/index.ts
+++ b/src/clients/order/transaction/update/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Update transaction operation -- sends `PUT /v1/orders/{id}/transactions/{transactionId}`.
  *
@@ -18,7 +19,7 @@ import { PaymentApiResponse } from '../../commonTypes';
  */
 export default function updateTransaction({ id, transactionId, body, config }: OrderUpdateTransactionClient): Promise<PaymentApiResponse> {
 	return RestClient.fetch<PaymentApiResponse>(
-		`/v1/orders/${id}/transactions/${transactionId}`,
+		`/v1/orders/${encodePathParam(id)}/transactions/${encodePathParam(transactionId)}`,
 		{
 			method: 'PUT',
 			headers: {

--- a/src/clients/point/cancelPaymentIntent/index.ts
+++ b/src/clients/point/cancelPaymentIntent/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the cancel-payment-intent operation for Point devices.
  *
@@ -19,7 +20,7 @@ import type { PointCancelPaymentIntentClient } from './types';
  */
 export default function cancelPaymentIntent({ device_id, payment_intent_id, config }: PointCancelPaymentIntentClient): Promise<CancelPaymentIntentResponse> {
 	return RestClient.fetch<CancelPaymentIntentResponse>(
-		`/point/integration-api/devices/${device_id}/payment-intents/${payment_intent_id}`,
+		`/point/integration-api/devices/${encodePathParam(device_id)}/payment-intents/${encodePathParam(payment_intent_id)}`,
 		{
 			method: 'DELETE',
 			headers: {

--- a/src/clients/point/changeDeviceOperatingMode/index.ts
+++ b/src/clients/point/changeDeviceOperatingMode/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the change-device-operating-mode operation.
  *
@@ -19,7 +20,7 @@ import type { PointChangeDeviceOperatingModeClient } from './types';
  */
 export default function changeDeviceOperatingMode({ device_id, request, config }: PointChangeDeviceOperatingModeClient): Promise<ChangeDeviceOperatingModeResponse> {
 	return RestClient.fetch<ChangeDeviceOperatingModeResponse>(
-		`/point/integration-api/devices/${device_id}`,
+		`/point/integration-api/devices/${encodePathParam(device_id)}`,
 		{
 			method: 'PATCH',
 			headers: {

--- a/src/clients/point/createPaymentIntent/index.ts
+++ b/src/clients/point/createPaymentIntent/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the create-payment-intent operation for Point devices.
  *
@@ -19,7 +20,7 @@ import type { PaymentIntentResponse } from '../commonTypes';
  */
 export default function createPaymentIntent({ device_id, request, config }: PointCreatePaymentIntentClient): Promise<PaymentIntentResponse> {
 	return RestClient.fetch<PaymentIntentResponse>(
-		`/point/integration-api/devices/${device_id}/payment-intents`,
+		`/point/integration-api/devices/${encodePathParam(device_id)}/payment-intents`,
 		{
 			method: 'POST',
 			headers: {

--- a/src/clients/point/getPaymentIntentList/index.ts
+++ b/src/clients/point/getPaymentIntentList/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the get-payment-intent-list operation.
  *

--- a/src/clients/point/getPaymentIntentStatus/index.ts
+++ b/src/clients/point/getPaymentIntentStatus/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the get-payment-intent-status operation.
  *
@@ -19,7 +20,7 @@ import type { PointGetPaymentIntentStatusClient } from './types';
  */
 export default function getPaymentIntentStatus({ payment_intent_id, config }: PointGetPaymentIntentStatusClient): Promise<PaymentIntentStatusResponse> {
 	return RestClient.fetch<PaymentIntentStatusResponse>(
-		`/point/integration-api/payment-intents/${payment_intent_id}/events`,
+		`/point/integration-api/payment-intents/${encodePathParam(payment_intent_id)}/events`,
 		{
 			method: 'GET',
 			headers: {

--- a/src/clients/point/searchPaymentIntent/index.ts
+++ b/src/clients/point/searchPaymentIntent/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the search-payment-intent operation.
  *
@@ -19,7 +20,7 @@ import type { PointSearchPaymentIntentClient } from './types';
  */
 export default function searchPaymentIntent({ payment_intent_id, config }: PointSearchPaymentIntentClient): Promise<PaymentIntentResponse> {
 	return RestClient.fetch<PaymentIntentResponse>(
-		`/point/integration-api/payment-intents/${payment_intent_id}`,
+		`/point/integration-api/payment-intents/${encodePathParam(payment_intent_id)}`,
 		{
 			method: 'GET',
 			headers: {

--- a/src/clients/preApproval/get/index.ts
+++ b/src/clients/preApproval/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the "get subscription" operation.
  *
@@ -19,7 +20,7 @@ import type { PreApprovalResponse } from '@src/clients/preApproval/commonTypes';
  */
 export default function get({ id, config }: PreApprovalGetClient): Promise<PreApprovalResponse> {
 	return RestClient.fetch<PreApprovalResponse>(
-		`/preapproval/${id}`,
+		`/preapproval/${encodePathParam(id)}`,
 		{
 			method: 'GET',
 			headers: {

--- a/src/clients/preApproval/update/index.ts
+++ b/src/clients/preApproval/update/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the "update subscription" operation.
  *
@@ -18,7 +19,7 @@ import type { PreApprovalUpdateClient, PreApprovalUpdateResponse } from './types
  */
 export default function update({ id, body, config }: PreApprovalUpdateClient): Promise<PreApprovalUpdateResponse> {
 	return RestClient.fetch<PreApprovalUpdateResponse>(
-		`/preapproval/${id}`,
+		`/preapproval/${encodePathParam(id)}`,
 		{
 			method: 'PUT',
 			headers: {

--- a/src/clients/preApprovalPlan/get/index.ts
+++ b/src/clients/preApprovalPlan/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the "get subscription plan" operation.
  *
@@ -19,7 +20,7 @@ import type { PreApprovalPlanResponse } from '@src/clients/preApprovalPlan/commo
  */
 export default function get({ id, config }: PreApprovalPlanGetClient): Promise<PreApprovalPlanResponse> {
 	return RestClient.fetch<PreApprovalPlanResponse>(
-		`/preapproval_plan/${id}`,
+		`/preapproval_plan/${encodePathParam(id)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/preApprovalPlan/update/index.ts
+++ b/src/clients/preApprovalPlan/update/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the "update subscription plan" operation.
  *
@@ -19,7 +20,7 @@ import type { PreApprovalPlanResponse } from '@src/clients/preApprovalPlan/commo
  */
 export default function update({ id, updatePreApprovalPlanRequest, config }: UpdatePreApprovalPlanUpdateClient): Promise<PreApprovalPlanResponse> {
 	return RestClient.fetch<PreApprovalPlanResponse>(
-		`/preapproval_plan/${id}`,
+		`/preapproval_plan/${encodePathParam(id)}`,
 		{
 			method: 'PUT',
 			headers: {

--- a/src/clients/preference/get/index.ts
+++ b/src/clients/preference/get/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the "get preference" operation.
  *
@@ -19,7 +20,7 @@ import type { PreferenceResponse } from '@src/clients/preference/commonTypes';
  */
 export default function get({ id, config }: PreferenceGetClient): Promise<PreferenceResponse> {
 	return RestClient.fetch<PreferenceResponse>(
-		`/checkout/preferences/${id}`,
+		`/checkout/preferences/${encodePathParam(id)}`,
 		{
 			headers: {
 				'Authorization': `Bearer ${config.accessToken}`

--- a/src/clients/preference/update/index.ts
+++ b/src/clients/preference/update/index.ts
@@ -1,3 +1,4 @@
+import { encodePathParam } from '@utils/path';
 /**
  * Implementation of the "update preference" operation.
  *
@@ -19,7 +20,7 @@ import type { PreferenceResponse } from '@src/clients/preference/commonTypes';
  */
 export default function update({ id, updatePreferenceRequest, config }: PreferenceUpdateClient): Promise<PreferenceResponse> {
 	return RestClient.fetch<PreferenceResponse>(
-		`/checkout/preferences/${id}`,
+		`/checkout/preferences/${encodePathParam(id)}`,
 		{
 			method: 'PUT',
 			headers: {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,5 @@
+function encodePathParam(value: string | number): string {
+	return encodeURIComponent(value.toString());
+}
+
+export { encodePathParam };


### PR DESCRIPTION
## Summary
- Adds a path-parameter encoder for dynamic API path segments.
- Applies encoding to string IDs used in customer, customer cards, chargeback, invoice, order, point, preapproval, preapproval plan and preference endpoints.
- Adds a regression assertion for traversal-style customer IDs.

## Validation
- Not run locally: this checkout does not have Jest available; npm test/pre-push fails with `jest: command not found`.