### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # Releases
 
+## VERSION 3.2.1 - 2026-07-22
+- Patch release: dependency updates and bug fixes.
+
 ## VERSION 3.2.0 - 2026-06-30
 - Order: Checkout PRO support — create online orders and redirect buyers to the Checkout PRO payment flow via `checkout_url`.
 - Order: New request types `CreateOrderConfig`, `OnlineConfigRequest`, `PaymentMethodConfigRequest` with full support for redirect URLs (`success_url`, `failure_url`, `pending_url`), `auto_return`, `allowed_user_type`, `available_from`, tracking pixels (Google Ads, Facebook Ads), and interest-free installment ranges.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mercadopago",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"description": "Mercadopago SDK for Node.js",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -36,7 +36,7 @@ export class AppConfig {
 	 * Embedded into the `User-Agent` and `X-Tracking-Id` headers so the
 	 * API can attribute traffic to a specific SDK release.
 	 */
-	static SDK_VERSION = '3.2.0';
+	static SDK_VERSION = '3.2.1';
 
 	/**
 	 * Canonical HTTP header names used in every request to the MercadoPago API.


### PR DESCRIPTION
## Summary
- Bump patch version from 3.2.0 to 3.2.1

## Files changed
- `package.json` — version updated to 3.2.1
- `src/utils/config/index.ts` — `SDK_VERSION` updated to 3.2.1
- `CHANGELOG.MD` — new entry added for 3.2.1

## Test plan
- [ ] Verify CI passes
- [ ] Confirm version string is correct in all files