### PR TITLE
chore: bump version to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mercadopago",
-	"version": "3.2.1",
+	"version": "3.3.0",
 	"description": "Mercadopago SDK for Node.js",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -42,7 +42,7 @@ export class AppConfig {
 	 * Embedded into the `User-Agent` and `X-Tracking-Id` headers so the
 	 * API can attribute traffic to a specific SDK release.
 	 */
-	static SDK_VERSION = '3.2.1';
+	static SDK_VERSION = '3.3.0';
 
 	/**
 	 * Canonical HTTP header names used in every request to the MercadoPago API.


### PR DESCRIPTION
## Summary

- Bump version from `3.2.1` to `3.3.0`
- Update `package.json`, `src/utils/config/index.ts`, and `CHANGELOG.md`

## Changelog entry

- feat: SDK ergonomics — typed errors, configurable retry and auto-pagination ([#462](https://github.com/mercadopago/sdk-nodejs/pull/462))
- feat: add missing API methods — `disbursementRefund.list()`, `advancedPayment.update()`, `customerCard.update()`, `payment.update()` ([#461](https://github.com/mercadopago/sdk-nodejs/pull/461))
- feat: add CREDENTIAL_ON_FILE messaging fields to Payment types ([#457](https://github.com/mercadopago/sdk-nodejs/pull/457)): `firstTransaction`, `storage`, `transactionInitiator`, `reference`
- fix: webhook `toleranceSeconds` unit mismatch ([#463](https://github.com/mercadopago/sdk-nodejs/pull/463))
- fix: `constantTimeEquals` `RangeError` on multibyte v1 hash ([#463](https://github.com/mercadopago/sdk-nodejs/pull/463))
- ci: upgrade dev dependencies and migrate to ESLint flat config ([#456](https://github.com/mercadopago/sdk-nodejs/pull/456))
- Bump `actions/setup-node` to `v7.0.0` ([#460](https://github.com/mercadopago/sdk-nodejs/pull/460))
- Bump `actions/checkout` to `v7.0.1` ([#455](https://github.com/mercadopago/sdk-nodejs/pull/455))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files