### PR TITLE
feat: add COF network data support + bump version to 3.5.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # Releases
 
+## VERSION 3.5.0 - 2026-08-25
+- feat: add COF network data support — new fields on `commonTypes.ts` and payment `create/types.ts`
+
 ## VERSION 3.4.0 - 2026-08-11
 - feat(order): add Automatic Payments example — two-step recurring flow ([#454](https://github.com/mercadopago/sdk-nodejs/pull/454))
 - feat(order): add missing typed fields to `CreateOrderRequest` and related interfaces ([#454](https://github.com/mercadopago/sdk-nodejs/pull/454))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mercadopago",
-	"version": "3.4.0",
+	"version": "3.5.0",
 	"description": "Mercadopago SDK for Node.js",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/clients/payment/commonTypes.ts
+++ b/src/clients/payment/commonTypes.ts
@@ -471,8 +471,14 @@ export declare type PointOfInteraction = {
   application_data?: ApplicationData;
   /** QR / PIX / ticket transaction data. */
   transaction_data?: TransactionData;
+  network_data?: NetworkData;
   /** Business context (unit / sub-unit). */
   business_info?: BusinessInfo;
+};
+
+export declare type NetworkData = {
+  network_transaction_id?: string;
+  transaction_link_id?: string;
 };
 
 /**
@@ -653,4 +659,3 @@ export declare interface PaymentResponse extends ApiResponse {
   /** Expanded fields requested via the `expand` query parameter. */
   expanded?: Expanded;
 }
-

--- a/src/clients/payment/create/types.ts
+++ b/src/clients/payment/create/types.ts
@@ -200,6 +200,12 @@ export declare type PointOfInteractionRequest = {
   sub_type?: string,
   /** Subscription / recurring transaction data. */
   transaction_data?: TransactionDataRequest,
+  network_data?: NetworkDataRequest,
+};
+
+export declare type NetworkDataRequest = {
+  network_transaction_id?: string,
+  transaction_link_id?: string,
 };
 
 /**

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -42,7 +42,7 @@ export class AppConfig {
 	 * Embedded into the `User-Agent` and `X-Tracking-Id` headers so the
 	 * API can attribute traffic to a specific SDK release.
 	 */
-	static SDK_VERSION = '3.4.0';
+	static SDK_VERSION = '3.5.0';
 
 	/**
 	 * Canonical HTTP header names used in every request to the MercadoPago API.


### PR DESCRIPTION
## Summary
- Add COF network data support: new fields on \`commonTypes.ts\` and payment \`create/types.ts\`
- Bump version from \`3.4.0\` to \`3.5.0\`
- Update \`package.json\`, \`src/utils/config/index.ts\`, \`CHANGELOG.md\`

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files