### PR TITLE
feat: support legacy COF network transaction id

### DIFF
--- a/src/clients/payment/commonTypes.ts
+++ b/src/clients/payment/commonTypes.ts
@@ -435,6 +435,8 @@ export declare type TransactionData = {
   bank_info?: BankInfo;
   /** URL to a printable payment ticket / voucher. */
   ticket_url?: string;
+  /** Legacy card-network transaction identifier within transaction data. */
+  network_transaction_id?: string;
   /** Whether this is the first transaction in a Credential on File agreement. */
   first_transaction?: boolean;
   /**

--- a/src/clients/payment/create/types.ts
+++ b/src/clients/payment/create/types.ts
@@ -231,6 +231,8 @@ export declare type TransactionDataRequest = {
   reference?: ReferenceRequest,
   /** Billing date for this charge (ISO 8601). */
   billing_date?: string,
+  /** Legacy card-network transaction identifier within transaction data. */
+  network_transaction_id?: string,
   /**
    * Indicates how the transaction was initiated.
    * `"customer"` – initiated by the cardholder; `"merchant"` – initiated by the merchant.


### PR DESCRIPTION
## Summary
- Add support for legacy COF network transaction id on `commonTypes.ts` and payment `create/types.ts`
- Follow-up to #471 (COF network data support), which already merged into master

## Test plan
- [ ] CI passes