### PR TITLE
Chore/npm trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,9 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -16,11 +19,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false
 
       - name: Install dependencies
-        run: npm install --legacy-peer-deps
+        run: npm ci --legacy-peer-deps
 
       - name: Build
         run: npm run build
@@ -33,5 +37,3 @@ jobs:
           else
             npm publish
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm install --legacy-peer-deps
 
       - name: Build
         run: npm run build

--- a/src/clients/payment/commonTypes.ts
+++ b/src/clients/payment/commonTypes.ts
@@ -437,6 +437,16 @@ export declare type TransactionData = {
   ticket_url?: string;
   /** Legacy card-network transaction identifier within transaction data. */
   network_transaction_id?: string;
+  /** Card-network identifiers associated with this transaction. */
+  network_data?: NetworkData;
+  /** Identifier of the subscription associated with this transaction. */
+  subscription_id?: string;
+  /** Position of this transaction within the subscription lifecycle. */
+  subscription_sequence?: SubscriptionSequenceResponse;
+  /** Billing period for the transaction's subscription invoice. */
+  invoice_period?: InvoicePeriodResponse;
+  /** Date on which the subscription charge was billed (ISO 8601). */
+  billing_date?: string;
   /** Whether this is the first transaction in a Credential on File agreement. */
   first_transaction?: boolean;
   /**
@@ -473,14 +483,25 @@ export declare type PointOfInteraction = {
   application_data?: ApplicationData;
   /** QR / PIX / ticket transaction data. */
   transaction_data?: TransactionData;
-  network_data?: NetworkData;
   /** Business context (unit / sub-unit). */
   business_info?: BusinessInfo;
 };
 
 export declare type NetworkData = {
-  network_transaction_id?: string;
+  transaction_id?: string;
   transaction_link_id?: string;
+};
+
+/** Position of a transaction within a subscription lifecycle. */
+export declare type SubscriptionSequenceResponse = {
+  number?: number;
+  total?: number;
+};
+
+/** Billing period covered by a subscription transaction. */
+export declare type InvoicePeriodResponse = {
+  period?: number;
+  type?: string;
 };
 
 /**
@@ -509,6 +530,8 @@ export declare type ThreeDSInfo = {
 export declare type GatewayReference = {
   /** Transaction ID assigned by the card network (Visa, Mastercard, etc.). */
   network_transaction_id?: string;
+  /** Card-network identifiers returned when the gateway reference is expanded. */
+  network_data?: NetworkData;
 };
 
 /**

--- a/src/clients/payment/create/create.spec.ts
+++ b/src/clients/payment/create/create.spec.ts
@@ -2,7 +2,8 @@ import create from '.';
 import { RestClient } from '@utils/restClient';
 import { MercadoPagoConfig } from '@src/mercadoPagoConfig';
 
-import type { PaymentCreateClient } from './types';
+import type { PaymentCreateClient, PaymentCreateRequest } from './types';
+import type { PaymentResponse } from '../commonTypes';
 
 jest.mock('@utils/restClient');
 
@@ -32,5 +33,63 @@ describe('Testing create payments', () => {
 				timeout: 5000
 			}
 		);
+	});
+
+	test('should serialize credential-on-file network data inside transaction data', async () => {
+		const client = new MercadoPagoConfig({ accessToken: 'token' });
+		const mockBody: PaymentCreateRequest = {
+			transaction_amount: 12.34,
+			payer: { email: 'email@example.com' },
+			point_of_interaction: {
+				type: 'CREDENTIAL_ON_FILE',
+				transaction_data: {
+					network_transaction_id: 'n7w-c0d3-t7d',
+					network_data: {
+						transaction_id: 'VISA-TID-ABC123',
+						transaction_link_id: '550e8400-e29b-41d4-a716-446655440000',
+					},
+				},
+			},
+		};
+
+		await create({ body: mockBody, config: client });
+
+		expect(jest.spyOn(RestClient, 'fetch')).toHaveBeenCalledWith('/v1/payments', expect.objectContaining({
+			body: JSON.stringify(mockBody),
+		}));
+	});
+
+	test('should expose credential-on-file network data and subscription fields in responses', () => {
+		const response: PaymentResponse = {
+			id: 123,
+			api_response: {
+				status: 200,
+				headers: ['content-type', ['application/json']],
+			},
+			point_of_interaction: {
+				transaction_data: {
+					network_transaction_id: 'n7w-c0d3-t7d',
+					network_data: {
+						transaction_id: 'VISA-TID-ABC123',
+						transaction_link_id: '550e8400-e29b-41d4-a716-446655440000',
+					},
+					subscription_id: 'subscription-123',
+					subscription_sequence: { number: 2, total: 12 },
+					invoice_period: { period: 1, type: 'monthly' },
+					billing_date: '2026-08-01',
+				},
+			},
+			expanded: {
+				gateway: {
+					reference: {
+						network_transaction_id: 'n7w-c0d3-t7d',
+						network_data: { transaction_id: 'VISA-TID-ABC123' },
+					},
+				},
+			},
+		};
+
+		expect(response.point_of_interaction?.transaction_data?.network_data?.transaction_id).toBe('VISA-TID-ABC123');
+		expect(response.expanded?.gateway?.reference?.network_data?.transaction_id).toBe('VISA-TID-ABC123');
 	});
 });

--- a/src/clients/payment/create/types.ts
+++ b/src/clients/payment/create/types.ts
@@ -200,12 +200,6 @@ export declare type PointOfInteractionRequest = {
   sub_type?: string,
   /** Subscription / recurring transaction data. */
   transaction_data?: TransactionDataRequest,
-  network_data?: NetworkDataRequest,
-};
-
-export declare type NetworkDataRequest = {
-  network_transaction_id?: string,
-  transaction_link_id?: string,
 };
 
 /**
@@ -233,6 +227,8 @@ export declare type TransactionDataRequest = {
   billing_date?: string,
   /** Legacy card-network transaction identifier within transaction data. */
   network_transaction_id?: string,
+  /** Card-network identifiers for credential-on-file transactions. */
+  network_data?: NetworkDataRequest,
   /**
    * Indicates how the transaction was initiated.
    * `"customer"` – initiated by the cardholder; `"merchant"` – initiated by the merchant.
@@ -243,6 +239,16 @@ export declare type TransactionDataRequest = {
    * `"store"` – credentials are being stored; `"stored"` – credentials were previously stored.
    */
   storage?: string,
+};
+
+/**
+ * Card-network identifiers associated with a credential-on-file transaction.
+ */
+export declare type NetworkDataRequest = {
+  /** Transaction ID assigned by the card network. */
+  transaction_id?: string,
+  /** Identifier linking related card-network transactions. */
+  transaction_link_id?: string,
 };
 
 /**


### PR DESCRIPTION
## Description

  Migrates the Node SDK release workflow to npm Trusted Publishing using GitHub Actions OIDC, removing the long-lived npm publish token. It also fixes the
  credential-on-file network_data contract in Payments so request and response types match the expected API structure.

  ## Changes

  - Configures GitHub Actions OIDC publishing with id-token: write.
  - Updates the release runtime to Node.js 24 and removes NODE_AUTH_TOKEN.
  - Preserves npm install --legacy-peer-deps in CD because the lockfile is ignored.
  - Moves point_of_interaction.network_data into point_of_interaction.transaction_data.network_data.
  - Renames network_transaction_id to transaction_id inside network_data.
  - Adds missing payment response fields:
      - subscription_id
      - subscription_sequence
      - invoice_period
      - billing_date
      - expanded.gateway.reference.network_data

  - Adds tests for the corrected request serialization and response typings.

  ## Testing

  - git diff --check passed.
  - Local Jest execution was not available because dependencies were not installed in the workspace.

  ## Follow-up

  Before the first release, configure npm Trusted Publishing for:

  - Organization: mercadopago
  - Repository: sdk-nodejs
  - Workflow: cd.yml
  - Allowed action: npm publish