### PR TITLE
feat(order): add automatic payment subscriptions

### DIFF
--- a/src/clients/order/commonTypes.ts
+++ b/src/clients/order/commonTypes.ts
@@ -328,6 +328,42 @@ export declare type AutomaticPayments = {
 	schedule_date?: string;
 	/** ISO 8601 due date for the payment. */
 	due_date?: string;
+	/** Subscription and invoice metadata for this automatic payment. */
+	subscription?: AutomaticPaymentsSubscription;
+}
+
+/**
+ * Subscription metadata attached to an automatic order payment.
+ */
+export declare type AutomaticPaymentsSubscription = {
+	/** Identifier of the subscription. */
+	id?: string;
+	/** Position of this charge within the subscription. */
+	sequence?: SubscriptionSequence;
+	/** Invoice information for this subscription charge. */
+	invoice?: AutomaticPaymentsInvoice;
+}
+
+/**
+ * Invoice metadata attached to an automatic payment subscription.
+ */
+export declare type AutomaticPaymentsInvoice = {
+	/** Identifier of the subscription invoice. */
+	id?: string;
+	/** ISO 8601 billing date of the invoice. */
+	billing_date?: string;
+	/** Billing period for the invoice. */
+	period?: AutomaticPaymentsPeriod;
+}
+
+/**
+ * Billing-period information for an automatic-payment subscription invoice.
+ */
+export declare type AutomaticPaymentsPeriod = {
+	/** Number of units in the billing period. */
+	interval?: number;
+	/** Billing-period unit, for example `month`. */
+	type?: string;
 }
 
 /**

--- a/src/clients/order/create/create.spec.ts
+++ b/src/clients/order/create/create.spec.ts
@@ -136,6 +136,36 @@ describe('Create Order', () => {
 			}
 		);
 	});
+
+	test('should serialize automatic payment subscription fields', async () => {
+		const config = new MercadoPagoConfig({ accessToken: 'access_token' });
+		const mockBody: CreateOrderRequest = {
+			type: 'online',
+			total_amount: '1000.00',
+			transactions: {
+				payments: [{
+					amount: '1000.00',
+					automatic_payments: {
+						subscription: {
+							id: 'subscription-1',
+							sequence: { number: 1, total: 12 },
+							invoice: {
+								id: 'invoice-1',
+								billing_date: '2026-08-26',
+								period: { interval: 1, type: 'month' },
+							},
+						},
+					},
+				}],
+			},
+		};
+
+		await create({ body: mockBody, config });
+
+		expect(jest.spyOn(RestClient, 'fetch')).toHaveBeenCalledWith('/v1/orders', expect.objectContaining({
+			body: JSON.stringify(mockBody),
+		}));
+	});
 });
 
 

--- a/src/clients/order/get/get.spec.ts
+++ b/src/clients/order/get/get.spec.ts
@@ -79,4 +79,30 @@ describe('Get Order', () => {
 		expect(result.config.payment_method.installments.interest_free.type).toBe('range');
 		expect(result.config.payment_method.installments.interest_free.values).toEqual([2, 6]);
 	});
+
+	test('should expose automatic payment subscription response fields', async () => {
+		const config = new MercadoPagoConfig({ accessToken: 'access_token' });
+		const mockOrderResponse: OrderResponse = {
+			api_response: { status: 200, headers: [] },
+			transactions: {
+				payments: [{
+					automatic_payments: {
+						subscription: {
+							id: 'subscription-1',
+							sequence: { number: 1, total: 12 },
+							invoice: { id: 'invoice-1', billing_date: '2026-08-26', period: { interval: 1, type: 'month' } },
+						},
+					},
+				}],
+			},
+		};
+		jest.spyOn(RestClient, 'fetch').mockResolvedValue(mockOrderResponse);
+
+		const result = await get({ id: 'order-1', config });
+		const subscription = result.transactions?.payments?.[0].automatic_payments?.subscription;
+
+		expect(subscription?.id).toBe('subscription-1');
+		expect(subscription?.sequence?.total).toBe(12);
+		expect(subscription?.invoice?.period?.type).toBe('month');
+	});
 });

--- a/src/clients/order/get/get.spec.ts
+++ b/src/clients/order/get/get.spec.ts
@@ -83,7 +83,7 @@ describe('Get Order', () => {
 	test('should expose automatic payment subscription response fields', async () => {
 		const config = new MercadoPagoConfig({ accessToken: 'access_token' });
 		const mockOrderResponse: OrderResponse = {
-			api_response: { status: 200, headers: [] },
+			api_response: { status: 200, headers: ['content-type', ['application/json']] },
 			transactions: {
 				payments: [{
 					automatic_payments: {


### PR DESCRIPTION
## Summary

Adds typed support for automatic_payments.subscription in Order request and response payloads.

## Changes

- Adds subscription, sequence, invoice, and billing-period types.
- Covers serialization in Order creation and response access in Order retrieval.
- Payments COF and expanded gateway network-data support were already present in master.

## Validation

Tests and build were not run locally because dependency installation was interrupted; CI should run the full suite.