### PR TITLE
chore: bump version to 3.6.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # Releases
 
+## VERSION 3.6.0 - 2026-08-27
+- feat(order): add `automatic_payments.subscription` request and response support
+
 ## VERSION 3.5.1 - 2026-08-26
 - fix: correct credential-on-file `network_data` nesting and field names in Payment requests and responses
 - fix: add missing credential-on-file subscription and gateway-reference response fields

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mercadopago",
-	"version": "3.5.1",
+	"version": "3.6.0",
 	"description": "Mercadopago SDK for Node.js",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -42,7 +42,7 @@ export class AppConfig {
 	 * Embedded into the `User-Agent` and `X-Tracking-Id` headers so the
 	 * API can attribute traffic to a specific SDK release.
 	 */
-	static SDK_VERSION = '3.5.1';
+	static SDK_VERSION = '3.6.0';
 
 	/**
 	 * Canonical HTTP header names used in every request to the MercadoPago API.


### PR DESCRIPTION
## Summary

Bumps the Node.js SDK release version to 3.6.0 after the latest merged backwards-compatible functionality.

## Files updated

- package.json
- src/utils/config/index.ts
- CHANGELOG.MD

## Validation

- Confirmed version metadata and changelog consistency.
- No runtime code changes.